### PR TITLE
adding rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80


### PR DESCRIPTION
with width=80 because we're living in 1975 and my monitor is powered by cathode-rays.